### PR TITLE
Update InstagramBasicDisplay.php

### DIFF
--- a/src/InstagramBasicDisplay.php
+++ b/src/InstagramBasicDisplay.php
@@ -59,7 +59,7 @@ class InstagramBasicDisplay
     public function getLoginUrl($scopes = ['user_profile', 'user_media'], $state = '')
     {
         if (is_array($scopes) && count(array_intersect($scopes, $this->_scopes)) === count($scopes)) {
-            return self::API_OAUTH_URL . '?app_id=' . $this->getAppId() . '&redirect_uri=' . urlencode($this->getRedirectUri()) . '&scope=' . implode(',',
+            return self::API_OAUTH_URL . '?client_id=' . $this->getAppId() . '&redirect_uri=' . urlencode($this->getRedirectUri()) . '&scope=' . implode(',',
                 $scopes) . '&response_type=code' . ($state != '' ? '&state=' . $state : '');
         }
 


### PR DESCRIPTION
Updated line 62 to reflect _client_id_ vs original _app_id_.
According to instagram API docs, client_id is required to get the code.

[https://developers.facebook.com/docs/instagram-basic-display-api/guides/getting-access-tokens-and-permissions](url)