### PR TITLE
Change requirements to php 5.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage": "https://github.com/espresso-dev/instagram-basic-display-php",
     "type": "library",
     "require": {
-        "php": ">=7",
+        "php": ">=5.6",
         "ext-curl": "*"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "302e94a7d21ebbb4d979f1894bab11d8",
+    "content-hash": "ca16009b9b2cfa015991077776e95f47",
     "packages": [],
     "packages-dev": [],
     "aliases": [],
@@ -13,8 +13,9 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.2.0",
+        "php": ">=5.6",
         "ext-curl": "*"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
I had to adapt this to a project running on an old server with php 5.6. I just changed the requirements in composer.json to accept php >= 5.6, and I've not found any incompatibilities.
If you don't plan on using specific features of newer php versions, this could help someone with my same problem.