### PR TITLE
[add] ext-json to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
     "type": "library",
     "require": {
         "php": ">=5.6",
-        "ext-curl": "*"
+        "ext-curl": "*",
+        "ext-json": "*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Using `json_decode` requires `ext-json` extension of PHP that must be specified in composer.json