### PR TITLE
Add PHPDoc

### DIFF
--- a/src/InstagramBasicDisplay.php
+++ b/src/InstagramBasicDisplay.php
@@ -13,9 +13,9 @@ class InstagramBasicDisplay
     const API_OAUTH_URL = 'https://api.instagram.com/oauth/authorize';
 
     const API_OAUTH_TOKEN_URL = 'https://api.instagram.com/oauth/access_token';
-    
+
     const API_TOKEN_EXCHANGE_URL = 'https://graph.instagram.com/access_token';
-    
+
     const API_TOKEN_REFRESH_URL = 'https://graph.instagram.com/refresh_access_token';
 
     /**
@@ -79,13 +79,13 @@ class InstagramBasicDisplay
             $this->setAppId($config['appId']);
             $this->setAppSecret($config['appSecret']);
             $this->setRedirectUri($config['redirectUri']);
-            
+
             if (isset($config['timeout'])) {
-                $this->setTimeout($config['timeout']);    
+                $this->setTimeout($config['timeout']);
             }
-            
+
             if (isset($config['connectTimeout'])) {
-                $this->setConnectTimeout($config['connectTimeout']);    
+                $this->setConnectTimeout($config['connectTimeout']);
             }
         } elseif (is_string($config)) {
             // For read-only

--- a/src/InstagramBasicDisplay.php
+++ b/src/InstagramBasicDisplay.php
@@ -2,6 +2,10 @@
 
 namespace EspressoDev\InstagramBasicDisplay;
 
+/**
+ * Class InstagramBasicDisplay
+ * @package EspressoDev\InstagramBasicDisplay
+ */
 class InstagramBasicDisplay
 {
     const API_URL = 'https://graph.instagram.com/';
@@ -14,27 +18,62 @@ class InstagramBasicDisplay
     
     const API_TOKEN_REFRESH_URL = 'https://graph.instagram.com/refresh_access_token';
 
+    /**
+     * @var string
+     */
     private $_appId;
 
+    /**
+     * @var string
+     */
     private $_appSecret;
 
+    /**
+     * @var string
+     */
     private $_redirectUri;
 
+    /**
+     * @var string
+     */
     private $_accesstoken;
 
+    /**
+     * @var string[]
+     */
     private $_scopes = ['user_profile', 'user_media'];
 
+    /**
+     * @var string
+     */
     private $_userFields = 'account_type, id, media_count, username';
 
+    /**
+     * @var string
+     */
     private $_mediaFields = 'caption, id, media_type, media_url, permalink, thumbnail_url, timestamp, username, children{id, media_type, media_url, permalink, thumbnail_url, timestamp, username}';
 
+    /**
+     * @var string
+     */
     private $_mediaChildrenFields = 'id, media_type, media_url, permalink, thumbnail_url, timestamp, username';
 
+    /**
+     * @var int
+     */
     private $_timeout = 90000;
 
+    /**
+     * @var int
+     */
     private $_connectTimeout = 20000;
 
-    public function __construct($config = null) 
+    /**
+     * InstagramBasicDisplay constructor.
+     * @param string[string]|string $config configuration parameters
+     * @throws InstagramBasicDisplayException
+     */
+    public function __construct($config = null)
     {
         if (is_array($config)) {
             $this->setAppId($config['appId']);
@@ -56,6 +95,12 @@ class InstagramBasicDisplay
         }
     }
 
+    /**
+     * @param string[] $scopes
+     * @param string $state
+     * @return string
+     * @throws InstagramBasicDisplayException
+     */
     public function getLoginUrl($scopes = ['user_profile', 'user_media'], $state = '')
     {
         if (is_array($scopes) && count(array_intersect($scopes, $this->_scopes)) === count($scopes)) {
@@ -66,6 +111,11 @@ class InstagramBasicDisplay
         throw new InstagramBasicDisplayException("Error: getLoginUrl() - The parameter isn't an array or invalid scope permissions used.");
     }
 
+    /**
+     * @param int $id
+     * @return object
+     * @throws InstagramBasicDisplayException
+     */
     public function getUserProfile($id = 0)
     {
         if ($id === 0) {
@@ -75,6 +125,14 @@ class InstagramBasicDisplay
         return $this->_makeCall($id, ['fields' => $this->_userFields]);
     }
 
+    /**
+     * @param string $id
+     * @param int $limit
+     * @param string|null $before
+     * @param string|null $after
+     * @return object
+     * @throws InstagramBasicDisplayException
+     */
     public function getUserMedia($id = 'me', $limit = 0, $before = null, $after = null)
     {
         $params = [
@@ -94,16 +152,31 @@ class InstagramBasicDisplay
         return $this->_makeCall($id . '/media', $params);
     }
 
+    /**
+     * @param string $id
+     * @return object
+     * @throws InstagramBasicDisplayException
+     */
     public function getMedia($id)
     {
         return $this->_makeCall($id, ['fields' => $this->_mediaFields]);
     }
 
+    /**
+     * @param string $id
+     * @return object
+     * @throws InstagramBasicDisplayException
+     */
     public function getMediaChildren($id)
     {
         return $this->_makeCall($id . '/children', ['fields' => $this->_mediaChildrenFields]);
     }
 
+    /**
+     * @param object $obj
+     * @return object|null
+     * @throws InstagramBasicDisplayException
+     */
     public function pagination($obj)
     {
         if (is_object($obj) && !is_null($obj->paging)) {
@@ -129,6 +202,12 @@ class InstagramBasicDisplay
         throw new InstagramBasicDisplayException("Error: pagination() | This method doesn't support pagination.");
     }
 
+    /**
+     * @param string $code
+     * @param bool $tokenOnly
+     * @return object|string
+     * @throws InstagramBasicDisplayException
+     */
     public function getOAuthToken($code, $tokenOnly = false)
     {
         $apiData = array(
@@ -144,6 +223,12 @@ class InstagramBasicDisplay
         return !$tokenOnly ? $result : $result->access_token;
     }
 
+    /**
+     * @param string $token
+     * @param bool $tokenOnly
+     * @return object|string
+     * @throws InstagramBasicDisplayException
+     */
     public function getLongLivedToken($token, $tokenOnly = false)
     {
         $apiData = array(
@@ -157,6 +242,12 @@ class InstagramBasicDisplay
         return !$tokenOnly ? $result : $result->access_token;
     }
 
+    /**
+     * @param string $token
+     * @param bool $tokenOnly
+     * @return object|string
+     * @throws InstagramBasicDisplayException
+     */
     public function refreshToken($token, $tokenOnly = false)
     {
         $apiData = array(
@@ -169,6 +260,13 @@ class InstagramBasicDisplay
         return !$tokenOnly ? $result : $result->access_token;
     }
 
+    /**
+     * @param string $function
+     * @param string[]|null $params
+     * @param string $method
+     * @return object
+     * @throws InstagramBasicDisplayException
+     */
     protected function _makeCall($function, $params = null, $method = 'GET')
     {
         if (!isset($this->_accesstoken)) {
@@ -209,6 +307,13 @@ class InstagramBasicDisplay
         return json_decode($jsonData);
     }
 
+    /**
+     * @param string $apiHost
+     * @param string[] $params
+     * @param string $method
+     * @return object
+     * @throws InstagramBasicDisplayException
+     */
     private function _makeOAuthCall($apiHost, $params, $method = 'POST')
     {
         $paramString = null;
@@ -225,7 +330,7 @@ class InstagramBasicDisplay
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($ch, CURLOPT_TIMEOUT_MS, $this->_timeout);
-        
+
         if ($method === 'POST') {
             curl_setopt($ch, CURLOPT_POST, count($params));
             curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($params));
@@ -242,66 +347,105 @@ class InstagramBasicDisplay
         return json_decode($jsonData);
     }
 
+    /**
+     * @param string $token
+     */
     public function setAccessToken($token)
     {
         $this->_accesstoken = $token;
     }
 
+    /**
+     * @return string
+     */
     public function getAccessToken()
     {
         return $this->_accesstoken;
     }
 
+    /**
+     * @param string $appId
+     */
     public function setAppId($appId)
     {
         $this->_appId = $appId;
     }
 
+    /**
+     * @return string
+     */
     public function getAppId()
     {
         return $this->_appId;
     }
 
+    /**
+     * @param string $appSecret
+     */
     public function setAppSecret($appSecret)
     {
         $this->_appSecret = $appSecret;
     }
 
+    /**
+     * @return string
+     */
     public function getAppSecret()
     {
         return $this->_appSecret;
     }
 
+    /**
+     * @param string $redirectUri
+     */
     public function setRedirectUri($redirectUri)
     {
         $this->_redirectUri = $redirectUri;
     }
 
+    /**
+     * @return string
+     */
     public function getRedirectUri()
     {
         return $this->_redirectUri;
     }
 
+    /**
+     * @param string $fields
+     */
     public function setUserFields($fields)
     {
         $this->_userFields = $fields;
     }
 
+    /**
+     * @param string $fields
+     */
     public function setMediaFields($fields)
     {
         $this->_mediaFields = $fields;
     }
 
+    /**
+     * @param string $fields
+     */
     public function setMediaChildrenFields($fields)
     {
         $this->_mediaChildrenFields = $fields;
     }
 
+    /**
+     * @param int $timeout
+     */
     public function setTimeout($timeout)
     {
         $this->_timeout = $timeout;
     }
 
+    /**
+     * @param int $connectTimeout
+     */
     public function setConnectTimeout($connectTimeout)
     {
         $this->_connectTimeout = $connectTimeout;

--- a/src/InstagramBasicDisplay.php
+++ b/src/InstagramBasicDisplay.php
@@ -108,13 +108,13 @@ class InstagramBasicDisplay
     {
         if (is_object($obj) && !is_null($obj->paging)) {
             if (!isset($obj->paging->next)) {
-                return;
+                return null;
             }
 
             $apiCall = explode('?', $obj->paging->next);
 
             if (count($apiCall) < 2) {
-                return;
+                return null;
             }
 
             $function = str_replace(self::API_URL, '', $apiCall[0]);


### PR DESCRIPTION
Changes:
- PHPDoc comments added. PHPDoc helps to avoid problems when using this library in IDEs like PHPStorm, that support types declaration and warnings of unhandled exceptions.
- removed unnecessary spaces
- in same cases when error happened functions returned `void`. Now they return `null`, so it's possible to detect if something goes wrong.

fixes #10 