### PR TITLE
[fix] add info about PHP5.6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A simple PHP wrapper for the Instagram Basic Display API. Based on the [Instagra
 
 ## Requirements
 
-- PHP 7 or higher
+- PHP 5.6 or higher
 - cURL
 - Facebook Developer Account
 - Facebook App


### PR DESCRIPTION
This project works with PHP 5.6 as it was adapted in #9 
However, the README is still missing this information and shows that PHP 7 is the minimal supported version.