### PR TITLE
Improve cURL response parsing for more stable body extraction

### DIFF
--- a/src/InstagramBasicDisplay.php
+++ b/src/InstagramBasicDisplay.php
@@ -294,13 +294,14 @@ class InstagramBasicDisplay
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
         curl_setopt($ch, CURLOPT_HEADER, true);
 
-        $jsonData = curl_exec($ch);
+        $response = curl_exec($ch);
 
-        if (!$jsonData) {
+        if (!$response) {
             throw new InstagramBasicDisplayException('Error: _makeCall() - cURL error: ' . curl_error($ch), curl_errno($ch));
         }
 
-        list($headerContent, $jsonData) = explode("\r\n\r\n", $jsonData, 2);
+        $responseParts = explode("\r\n\r\n", $response);
+        $jsonData = $responseParts[array_key_last($responseParts)];
 
         curl_close($ch);
 


### PR DESCRIPTION
During debugging I found that my cURL response does not match the expected shape by the current body parsing logic.

cuRL response string
```
HTTP/1.0 200 Connection established

HTTP/2 200
etag: "40eb12e1db3bd316a20e421579eb0c9319c33029"
content-type: application/json; charset=UTF-8
vary: Origin
vary: Accept-Encoding
cross-origin-resource-policy: cross-origin
x-app-usage: {"call_volume":2,"cpu_time":0}
instagram-api-version: v13.0
access-control-allow-origin: *
strict-transport-security: max-age=15552000
pragma: no-cache
cache-control: private, no-cache, no-store, must-revalidate
expires: Sat, 01 Jan 2000 00:00:00 GMT
x-fb-request-id: A3EagUez3D06PfR2W7NCLRo
x-fb-trace-id: HjzEzEg1A1S
x-fb-rev: 1006485593
x-fb-debug: ey8syhgmGO8S8cxwdQ5TguFJJNvNleHMzmgtAyqg29Fu78JsqDEEjeE24i0ZK9paxiv8amEK9ieEFTptkhx+0w==
date: Fri, 28 Oct 2022 06:43:12 GMT
priority: u=3,i
x-fb-trip-id: 1814657579

{"data":[],"paging":{}}
```

after trying to explode the json data from the cURL response string.

`$headerContent`
```
HTTP/1.0 200 Connection established
```

`$jsonData`
```
HTTP/2 200
etag: "40eb12e1db3bd316a20e421579eb0c9319c33029"
content-type: application/json; charset=UTF-8
vary: Origin
vary: Accept-Encoding
cross-origin-resource-policy: cross-origin
x-app-usage: {"call_volume":2,"cpu_time":0}
instagram-api-version: v13.0
access-control-allow-origin: *
strict-transport-security: max-age=15552000
pragma: no-cache
cache-control: private, no-cache, no-store, must-revalidate
expires: Sat, 01 Jan 2000 00:00:00 GMT
x-fb-request-id: A3EagUez3D06PfR2W7NCLRo
x-fb-trace-id: HjzEzEg1A1S
x-fb-rev: 1006485593
x-fb-debug: ey8syhgmGO8S8cxwdQ5TguFJJNvNleHMzmgtAyqg29Fu78JsqDEEjeE24i0ZK9paxiv8amEK9ieEFTptkhx+0w==
date: Fri, 28 Oct 2022 06:43:12 GMT
priority: u=3,i
x-fb-trip-id: 1814657579

{"data":[],"paging":{}}
```

`$jsonData` has no valid json string which ca be decoded. So json_decode returns `null`